### PR TITLE
Feat/inbound detail

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,7 @@ export default [
 			}
 		},
 		rules: {
-			'@typescript-eslint/no-explicit-any': 'warn',
+			'@typescript-eslint/no-explicit-any': 'off',
 			'react/react-in-jsx-scope': 'off',
 			'@typescript-eslint/no-unused-vars': 'warn',
 			'@typescript-eslint/no-non-null-asserted-optional-chain': 'warn',

--- a/src/app/(features)/_layout.inbound-report/_components/-report-datalist.tsx
+++ b/src/app/(features)/_layout.inbound-report/_components/-report-datalist.tsx
@@ -3,10 +3,22 @@ import { useAuth } from '@/common/hooks/use-auth'
 import useMediaQuery from '@/common/hooks/use-media-query'
 import useQueryParams from '@/common/hooks/use-query-params'
 import { IInboundReport } from '@/common/types/entities'
-import { Button, DataTable, Div, Icon, Tooltip } from '@/components/ui'
+import {
+	Badge,
+	Button,
+	DataTable,
+	Div,
+	Icon,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+	Tooltip
+} from '@/components/ui'
 import { ReportService } from '@/services/report.service'
 import { createColumnHelper } from '@tanstack/react-table'
-import { format } from 'date-fns'
 import { saveAs } from 'file-saver'
 import { Fragment, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -15,6 +27,8 @@ import { useGetTenantByFactory } from '../../_apis/use-tenacy.api'
 
 import { useGetInboundReport } from '@/app/(features)/_apis/use-report.api'
 import { ROW_EXPANSION_COLUMN_ID } from '@/components/ui/@react-table/constants'
+import { RenderSubComponent } from '@/components/ui/@react-table/types'
+import { isNil } from 'lodash'
 import DatePickerFilter from './-date-picker-filter'
 
 const DOWNLOAD_INBOUND_REPORT_ID = 'download-inbound-report'
@@ -41,16 +55,20 @@ const ReportDatalist: React.FC = () => {
 		() => [
 			columnHelper.display({
 				id: ROW_EXPANSION_COLUMN_ID,
-				header: '',
+				header: ({ table }) => (
+					<button onClick={() => table.toggleAllRowsExpanded(false)}>
+						<Icon name='SquareMinus' />
+					</button>
+				),
 				size: 50,
 				maxSize: 50,
 				enableResizing: false,
-				cell: ({ row }) => (
+				cell: ({ row, table }) => (
 					<button
-						className='w-full'
+						className='absolute inset-0 flex h-full w-full items-center justify-center'
 						onClick={() => {
-							console.log(row.id)
-							row.toggleExpanded()
+							table.toggleAllRowsExpanded(false)
+							row.toggleExpanded(!row.getIsExpanded())
 						}}>
 						<Icon name={row.getIsExpanded() ? 'ChevronDown' : 'ChevronRight'} />
 					</button>
@@ -76,21 +94,31 @@ const ReportDatalist: React.FC = () => {
 				cell: ({ getValue }) => getValue() ?? 'Unknown',
 				minSize: 200
 			}),
-			columnHelper.accessor('shaping_dept_name', {
-				header: t('ns_erp:fields.shaping_dept_name'),
+			columnHelper.accessor('mat_ecolor', {
+				header: t('ns_erp:fields.mat_ecolor'),
 				enableColumnFilter: true,
 				enableSorting: true,
 				cell: ({ getValue }) => getValue() ?? 'Unknown',
 				minSize: 200
 			}),
-			columnHelper.accessor('station_no', {
-				header: 'Station NO',
+			columnHelper.accessor('shaping_dept_name', {
+				header: t('ns_erp:fields.shaping_dept_name'),
 				enableColumnFilter: true,
 				enableSorting: true,
 				minSize: 200,
-				filterFn: 'equals',
-				meta: {
-					filterVariant: 'select'
+				filterFn: 'includesString',
+				cell: ({ getValue }) => {
+					const value = getValue()
+					// return value
+					return (
+						<Div className='space-x-1'>
+							{value.split(',').map((item) => (
+								<Badge key={item} variant='outline'>
+									{item}
+								</Badge>
+							))}
+						</Div>
+					)
 				}
 			}),
 			columnHelper.accessor('order_qty', {
@@ -102,8 +130,8 @@ const ReportDatalist: React.FC = () => {
 				cell: ({ getValue }) => new Intl.NumberFormat().format(getValue()),
 				minSize: 250
 			}),
-			columnHelper.accessor('inbound_qty', {
-				header: t('ns_erp:fields.inbound_qty'),
+			columnHelper.accessor('daily_inbound_qty', {
+				header: t('ns_erp:fields.daily_inbound_qty'),
 				enableColumnFilter: true,
 				enableSorting: true,
 				meta: { filterVariant: 'range', align: 'right' },
@@ -111,15 +139,29 @@ const ReportDatalist: React.FC = () => {
 				cell: ({ getValue }) => new Intl.NumberFormat().format(getValue()),
 				minSize: 250
 			}),
-			columnHelper.accessor('inbound_date', {
-				header: t('ns_erp:fields.inbound_date'),
+			columnHelper.accessor('accumulated_inbound_qty', {
+				header: t('ns_erp:fields.accumulated_inbound_qty'),
 				enableColumnFilter: true,
 				enableSorting: true,
-				enableResizing: true,
-				cell: ({ getValue }) => {
-					const value = getValue()
-					return format(value, 'yyyy-MM-dd')
-				}
+				meta: { filterVariant: 'range', align: 'right' },
+				filterFn: 'inNumberRange',
+				cell: ({ getValue }) => new Intl.NumberFormat().format(getValue()),
+				minSize: 250
+			}),
+			columnHelper.display({
+				id: 'missing_qty',
+				header: t('ns_erp:fields.missing_qty'),
+				enableColumnFilter: true,
+				enableSorting: true,
+				meta: { filterVariant: 'range', align: 'right' },
+				filterFn: 'inNumberRange',
+				cell: ({ row }) => {
+					const { order_qty, accumulated_inbound_qty } = row.original
+					return !isNil(order_qty) && order_qty >= 0
+						? new Intl.NumberFormat().format(order_qty - accumulated_inbound_qty)
+						: 0
+				},
+				minSize: 250
 			})
 		],
 		[i18n.language]
@@ -129,7 +171,7 @@ const ReportDatalist: React.FC = () => {
 		toast.loading(t('ns_common:notification.downloading'), { id: DOWNLOAD_INBOUND_REPORT_ID })
 		try {
 			const blob = await ReportService.downloadInboundReport(currentTenant?.id, searchParams)
-			saveAs(blob, `Inbound Report ~ ${format(new Date(), 'yyyy-MM-dd')}.xlsx`)
+			saveAs(blob, `Inbound Report ~ ${searchParams['date.eq']}.xlsx`)
 			toast.success(t('ns_common:notification.success'), { id: DOWNLOAD_INBOUND_REPORT_ID })
 		} catch {
 			toast.error('ns_common:notification.error', { id: DOWNLOAD_INBOUND_REPORT_ID })
@@ -142,7 +184,12 @@ const ReportDatalist: React.FC = () => {
 			data={data}
 			loading={isLoading}
 			enableExpanding={true}
-			renderSubComponent={({ row }) => <Div>{JSON.stringify(row)}</Div>}
+			containerProps={{ className: 'h-[65vh]' }}
+			renderSubComponent={
+				(({ row }) => {
+					return <InboundReportDetailTable data={row.original?.size_run} />
+				}) satisfies RenderSubComponent<IInboundReport>
+			}
 			toolbarProps={{
 				slotLeft: () => isSmallScreen && <DatePickerFilter />,
 				slotRight: () => (
@@ -161,6 +208,44 @@ const ReportDatalist: React.FC = () => {
 				)
 			}}
 		/>
+	)
+}
+
+const InboundReportDetailTable: React.FC<{ data: IInboundReport['size_run'] }> = ({ data }) => {
+	const { t } = useTranslation()
+
+	return (
+		<Div className='w-1/3 overflow-clip rounded-md border'>
+			<Table className='table-fixed !border-none'>
+				<TableHeader>
+					<TableRow>
+						<TableHead className='w-20'>Size</TableHead>
+						<TableHead className='w-20'>{t('ns_erp:fields.inbound_qty')}</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{Array.isArray(data) && data.length > 0 ? (
+						data.map((item) => (
+							<TableRow key={item.size_numcode}>
+								<TableCell align='center' className='font-medium'>
+									{item.size_numcode}
+								</TableCell>
+								<TableCell align='center' className='w-10' key={item.inbound_qty}>
+									{item.inbound_qty}
+								</TableCell>
+								{data.length === 0 && <TableCell></TableCell>}
+							</TableRow>
+						))
+					) : (
+						<TableRow>
+							<TableCell align='center' colSpan={2} className='font-medium'>
+								No data
+							</TableCell>
+						</TableRow>
+					)}
+				</TableBody>
+			</Table>
+		</Div>
 	)
 }
 

--- a/src/app/(features)/_layout.inbound-report/_components/-report-datalist.tsx
+++ b/src/app/(features)/_layout.inbound-report/_components/-report-datalist.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '@/common/hooks/use-auth'
 import useMediaQuery from '@/common/hooks/use-media-query'
 import useQueryParams from '@/common/hooks/use-query-params'
 import { IInboundReport } from '@/common/types/entities'
-import { Button, DataTable, Icon, Tooltip } from '@/components/ui'
+import { Button, DataTable, Div, Icon, Tooltip } from '@/components/ui'
 import { ReportService } from '@/services/report.service'
 import { createColumnHelper } from '@tanstack/react-table'
 import { format } from 'date-fns'
@@ -14,6 +14,7 @@ import { toast } from 'sonner'
 import { useGetTenantByFactory } from '../../_apis/use-tenacy.api'
 
 import { useGetInboundReport } from '@/app/(features)/_apis/use-report.api'
+import { ROW_EXPANSION_COLUMN_ID } from '@/components/ui/@react-table/constants'
 import DatePickerFilter from './-date-picker-filter'
 
 const DOWNLOAD_INBOUND_REPORT_ID = 'download-inbound-report'
@@ -38,6 +39,23 @@ const ReportDatalist: React.FC = () => {
 
 	const columns = useMemo(
 		() => [
+			columnHelper.display({
+				id: ROW_EXPANSION_COLUMN_ID,
+				header: '',
+				size: 50,
+				maxSize: 50,
+				enableResizing: false,
+				cell: ({ row }) => (
+					<button
+						className='w-full'
+						onClick={() => {
+							console.log(row.id)
+							row.toggleExpanded()
+						}}>
+						<Icon name={row.getIsExpanded() ? 'ChevronDown' : 'ChevronRight'} />
+					</button>
+				)
+			}),
 			columnHelper.accessor('mo_no', {
 				header: t('ns_erp:fields.mo_no'),
 				enableColumnFilter: true,
@@ -123,6 +141,8 @@ const ReportDatalist: React.FC = () => {
 			columns={columns}
 			data={data}
 			loading={isLoading}
+			enableExpanding={true}
+			renderSubComponent={({ row }) => <Div>{JSON.stringify(row)}</Div>}
 			toolbarProps={{
 				slotLeft: () => isSmallScreen && <DatePickerFilter />,
 				slotRight: () => (

--- a/src/app/(features)/_layout.inbound-report/_components/-report-datalist.tsx
+++ b/src/app/(features)/_layout.inbound-report/_components/-report-datalist.tsx
@@ -56,9 +56,13 @@ const ReportDatalist: React.FC = () => {
 			columnHelper.display({
 				id: ROW_EXPANSION_COLUMN_ID,
 				header: ({ table }) => (
-					<button onClick={() => table.toggleAllRowsExpanded(false)}>
-						<Icon name='SquareMinus' />
-					</button>
+					<Tooltip message={t('ns_common:actions.fold')} triggerProps={{ asChild: true }}>
+						<button
+							className='absolute inset-0 flex h-full w-full items-center justify-center'
+							onClick={() => table.toggleAllRowsExpanded(false)}>
+							<Icon name='FoldVertical' stroke='hsl(var(--foreground))' />
+						</button>
+					</Tooltip>
 				),
 				size: 50,
 				maxSize: 50,
@@ -215,12 +219,12 @@ const InboundReportDetailTable: React.FC<{ data: IInboundReport['size_run'] }> =
 	const { t } = useTranslation()
 
 	return (
-		<Div className='w-1/3 overflow-clip rounded-md border'>
+		<Div className='w-1/4 overflow-clip rounded-md border'>
 			<Table className='table-fixed !border-none'>
 				<TableHeader>
 					<TableRow>
-						<TableHead className='w-20'>Size</TableHead>
-						<TableHead className='w-20'>{t('ns_erp:fields.inbound_qty')}</TableHead>
+						<TableHead>Size</TableHead>
+						<TableHead>{t('ns_erp:fields.inbound_qty')}</TableHead>
 					</TableRow>
 				</TableHeader>
 				<TableBody>

--- a/src/common/types/entities.d.ts
+++ b/src/common/types/entities.d.ts
@@ -178,9 +178,15 @@ export interface IInOutBoundReport {
 
 export interface IInboundReport extends IInOutBoundReport {
 	shaping_dept_name: string
-	inbound_qty: number
+	mat_ecolor: string
 	station_no: string
-	inbound_date: string | Date
+	daily_inbound_qty: number
+	accumulated_inbound_qty: number
+	missing_qty: number
+	size_run: Array<{
+		size_numcode: string
+		inbound_qty: number
+	}>
 }
 export interface IOutboundReport extends IInOutBoundReport {
 	shaping_dept_name: string

--- a/src/components/ui/@core/table.tsx
+++ b/src/components/ui/@core/table.tsx
@@ -7,7 +7,7 @@ const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableE
 		<table
 			cellSpacing={0}
 			ref={ref}
-			className={cn('w-full caption-bottom border-collapse text-sm', className)}
+			className={cn('w-full caption-bottom border-collapse rounded-md border text-sm', className)}
 			{...props}
 		/>
 	)

--- a/src/components/ui/@custom/typography.tsx
+++ b/src/components/ui/@custom/typography.tsx
@@ -28,6 +28,7 @@ export const typographyVariants = cva('', {
 			primary: 'text-primary',
 			accent: 'text-accent',
 			active: 'text-active',
+			warning: 'text-warning',
 			secondary: 'text-secondary',
 			muted: 'text-muted-foreground',
 			success: 'text-success',

--- a/src/components/ui/@react-table/components/table-body.tsx
+++ b/src/components/ui/@react-table/components/table-body.tsx
@@ -11,7 +11,7 @@ import { DataTableUtility } from '../utils/table.util'
 type TableBodyProps = {
 	table: TTable<any>
 	virtualizer: Virtualizer<HTMLDivElement, Element>
-	renderSubComponent: RenderSubComponent
+	renderSubComponent: RenderSubComponent<any>
 }
 
 export const TableBody: React.FC<TableBodyProps> = ({ table, virtualizer, renderSubComponent }) => {
@@ -70,17 +70,19 @@ export const TableBody: React.FC<TableBodyProps> = ({ table, virtualizer, render
 							<TableRow data-index={virtualRow.index}>
 								<TableCell
 									colSpan={row.getVisibleCells().length}
-									className={cn('p-0', !row.getIsExpanded() ? 'border-none shadow-none' : 'shadow-inner')}>
+									className={cn(
+										'p-0',
+										!row.getIsExpanded() ? 'border-none shadow-none' : 'shadow-[inset_0_0px_4px_#17171725]'
+									)}>
 									<Collapsible data-state={row.getIsExpanded() ? 'open' : 'closed'} open={row.getIsExpanded()}>
 										<CollapsibleContent
 											style={{
 												width: 'var(--table-width)',
 												position: 'sticky',
 												left: '0'
-												// maxWidth: `calc(${tableWrapperRef.current?.clientWidth}px - var(--scrollbar-width, 16px))`
 											}}
-											className='max-w- transition-all ease-in-out data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down'>
-											<Div className='p-4'>
+											className='overflow-auto bg-secondary/50 transition-all ease-in-out data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down'>
+											<Div className='flex items-center justify-center p-4'>
 												{typeof renderSubComponent === 'function' && renderSubComponent({ table, row })}
 											</Div>
 										</CollapsibleContent>

--- a/src/components/ui/@react-table/components/table-body.tsx
+++ b/src/components/ui/@react-table/components/table-body.tsx
@@ -74,11 +74,12 @@ export const TableBody: React.FC<TableBodyProps> = ({ table, virtualizer, render
 									<Collapsible data-state={row.getIsExpanded() ? 'open' : 'closed'} open={row.getIsExpanded()}>
 										<CollapsibleContent
 											style={{
+												width: 'var(--table-width)',
 												position: 'sticky',
 												left: '0'
 												// maxWidth: `calc(${tableWrapperRef.current?.clientWidth}px - var(--scrollbar-width, 16px))`
 											}}
-											className='transition-all ease-in-out data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down'>
+											className='max-w- transition-all ease-in-out data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down'>
 											<Div className='p-4'>
 												{typeof renderSubComponent === 'function' && renderSubComponent({ table, row })}
 											</Div>

--- a/src/components/ui/@react-table/components/table-body.tsx
+++ b/src/components/ui/@react-table/components/table-body.tsx
@@ -81,10 +81,8 @@ export const TableBody: React.FC<TableBodyProps> = ({ table, virtualizer, render
 												position: 'sticky',
 												left: '0'
 											}}
-											className='overflow-auto bg-secondary/50 transition-all ease-in-out data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down'>
-											<Div className='flex items-center justify-center p-4'>
-												{typeof renderSubComponent === 'function' && renderSubComponent({ table, row })}
-											</Div>
+											className='overflow-auto bg-secondary/50 p-3 transition-all ease-in-out data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down'>
+											{typeof renderSubComponent === 'function' && renderSubComponent({ table, row })}
 										</CollapsibleContent>
 									</Collapsible>
 								</TableCell>

--- a/src/components/ui/@react-table/components/table.tsx
+++ b/src/components/ui/@react-table/components/table.tsx
@@ -103,7 +103,7 @@ function TableDataGrid<TData, TValue>({
 		<Wrapper
 			ref={wrapperRef}
 			style={{
-				'--table-width': wrapperSize?.width + 'px'
+				'--table-width': wrapperSize?.width - 8 + 'px'
 			}}>
 			{caption && <TableHeadCaption id={captionId} aria-description={caption} />}
 			<ScrollArea tabIndex={0} ref={containerRef} {...containerProps}>

--- a/src/components/ui/@react-table/components/table.tsx
+++ b/src/components/ui/@react-table/components/table.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/common/utils/cn'
 import { type Table as TTable } from '@tanstack/react-table'
 import { elementScroll, useVirtualizer, VirtualizerOptions } from '@tanstack/react-virtual'
+import { useSize } from 'ahooks'
 import { Fragment, useCallback, useId, useMemo, useRef } from 'react'
 import tw from 'tailwind-styled-components'
 import { Collapsible, CollapsibleContent, Table, TableCaption, TableHead, TableHeader, TableRow } from '../..'
@@ -94,8 +95,16 @@ function TableDataGrid<TData, TValue>({
 		return colSizes
 	}, [table.getState().columnSizingInfo, table.getState().columnSizing])
 
+	const wrapperRef = useRef<HTMLDivElement>(null)
+
+	const wrapperSize = useSize(wrapperRef)
+
 	return (
-		<Wrapper>
+		<Wrapper
+			ref={wrapperRef}
+			style={{
+				'--table-width': wrapperSize?.width + 'px'
+			}}>
 			{caption && <TableHeadCaption id={captionId} aria-description={caption} />}
 			<ScrollArea tabIndex={0} ref={containerRef} {...containerProps}>
 				<Table

--- a/src/components/ui/@react-table/components/table.tsx
+++ b/src/components/ui/@react-table/components/table.tsx
@@ -67,14 +67,11 @@ function TableDataGrid<TData, TValue>({
 
 		requestAnimationFrame(run)
 	}, [])
-
+	console.log(table.getExpandedRowModel().flatRows.length)
 	const virtualizer = useVirtualizer({
 		count: rows.length,
 		indexAttribute: 'data-index',
-		overscan:
-			table.getCanSomeRowsExpand() && table.getIsSomeRowsExpanded()
-				? table.getExpandedRowModel().flatRows.length
-				: 5,
+		overscan: table.getIsSomeRowsExpanded() ? table.getExpandedRowModel().flatRows.length : 5,
 		getScrollElement: () => containerRef.current,
 		estimateSize: useCallback(() => ESTIMATE_SIZE, []),
 		measureElement:
@@ -96,7 +93,6 @@ function TableDataGrid<TData, TValue>({
 	}, [table.getState().columnSizingInfo, table.getState().columnSizing])
 
 	const wrapperRef = useRef<HTMLDivElement>(null)
-
 	const wrapperSize = useSize(wrapperRef)
 
 	return (

--- a/src/components/ui/@react-table/types/index.d.ts
+++ b/src/components/ui/@react-table/types/index.d.ts
@@ -80,7 +80,15 @@ type SortingProps =
 			onSortingChange?: React.Dispatch<React.SetStateAction<SortingState>>
 	  }
 
-export type RenderSubComponent = (props: { row: Row<TData & any>; table: Table<TData, TValue> }) => React.ReactElement
+type RenderSubComponentProps<TData = any, TValue = any> = {
+	row: Row<TData>
+	table: Table<TData, TValue>
+}
+
+export type RenderSubComponent<TData, TValue = any> = (props: {
+	row: Row<TData>
+	table: Table<TData, TValue>
+}) => React.ReactElement
 
 // #region Data table prop types
 export type DataTableProps<TData = any, TValue = any> = {
@@ -95,7 +103,7 @@ export type DataTableProps<TData = any, TValue = any> = {
 	sorting?: SortingState
 	initialState?: Partial<TableState>
 	onStateChange?: (instance: Table<TData, TValue>) => void
-	renderSubComponent?: RenderSubComponent
+	renderSubComponent?: (props: RenderSubComponentProps<TData, TValue>) => React.ReactElement
 } & Partial<TableOptions<any>> &
 	PaginationProps<TData> &
 	ColumnFilterProps &

--- a/src/i18n/cn/ns_common.i18n.ts
+++ b/src/i18n/cn/ns_common.i18n.ts
@@ -17,6 +17,7 @@ export default {
 		dismiss: '忽略',
 		export: '导出',
 		finish: '完成',
+		fold: '折叠',
 		load_more: '加载更多',
 		login: '登入',
 		logout: '登出',

--- a/src/i18n/cn/ns_erp.i18n.ts
+++ b/src/i18n/cn/ns_erp.i18n.ts
@@ -1,10 +1,12 @@
 export default {
 	fields: {
+		accumulated_inbound_qty: '累计',
 		active_date: '入库日期',
 		brand_name: '品牌',
 		container_order_code: '出櫃單號',
 		conversion_rate: '換算率',
 		customer_order: '客户订单',
+		daily_inbound_qty: '日产量',
 		dept_code: '成型線',
 		dept_name: '更新部門',
 		employee_name: '建檔人姓名',
@@ -15,6 +17,8 @@ export default {
 		kg_noend: '結束箱號',
 		kg_nostart: '起始箱號',
 		mat_code: '成品料号',
+		mat_ecolor: '产品颜色',
+		missing_qty: '缺貨量',
 		mo_no: '指令碼',
 		mo_no_actual: '實際指令碼',
 		no_crates_in_stock: '入库箱数',

--- a/src/i18n/en/ns_common.i18n.ts
+++ b/src/i18n/en/ns_common.i18n.ts
@@ -17,6 +17,7 @@ export default {
 		dismiss: 'Dismiss',
 		export: 'Export',
 		finish: 'Finish',
+		fold: 'Fold',
 		load_more: 'Load more',
 		login: 'Log in',
 		logout: 'Log out',

--- a/src/i18n/en/ns_erp.i18n.ts
+++ b/src/i18n/en/ns_erp.i18n.ts
@@ -1,10 +1,12 @@
 export default {
 	fields: {
+		accumulated_inbound_qty: 'Accumulated inbound quantity',
 		brand_name: 'Customer branch name',
 		container_order_code: 'Container Order Code',
 		conversion_rate: 'Conversion rate',
 		customer_branch_id: 'Customer branch ID',
 		customer_order: 'Customer order code', //: Đặt đơn của khách
+		daily_inbound_qty: 'Daily inbound quantity',
 		dept_name: 'Department',
 		employee_name: "Employee's name",
 		export_num: 'Qty. of goods shipped', //: Số đã xuất kho
@@ -14,6 +16,8 @@ export default {
 		kg_noend: 'Ending Box Number',
 		kg_nostart: 'Starting Box Number',
 		mat_code: 'Finished production code',
+		mat_ecolor: 'Product color',
+		missing_qty: 'Missing quantity',
 		mo_no: 'Manufacturing order',
 		mo_no_actual: 'Actual manufacturing order',
 		no_crates_in_stock: 'No. crates in stock', //: Số thùng nhập kho

--- a/src/i18n/vi/ns_common.i18n.ts
+++ b/src/i18n/vi/ns_common.i18n.ts
@@ -16,6 +16,7 @@ export default {
 		dismiss: 'Bỏ qua',
 		export: 'Xuất',
 		finish: 'Hoàn thành',
+		fold: 'Thu gọn',
 		load_more: 'Tải thêm',
 		login: 'Đăng nhập',
 		logout: 'Đăng xuất',

--- a/src/i18n/vi/ns_erp.i18n.ts
+++ b/src/i18n/vi/ns_erp.i18n.ts
@@ -1,11 +1,14 @@
 export default {
 	fields: {
+		accumulated_inbound_qty: 'Số lượng nhập kho tích lũy',
 		brand_name: 'Nhãn hiệu khách hàng',
 		container_order_code: 'Mã Đơn Xuất Công', // Container Order Code
 		conversion_rate: 'Tỷ Lệ Chuyển Đổi', // Conversion Rate
 		customer_branch_id: 'ID nhã hiệu khách hàng',
 		customer_order: 'Đặt đơn của khách',
+		daily_inbound_qty: 'Số lượng nhập kho hàng ngày',
 		dept_name: 'Bộ phận cập nhật',
+		employee_name: 'Nhân viên tạo đơn',
 		export_num: 'Số đã xuất kho',
 		inbound_date: 'Ngày Nhập Kho', // Inbound Date
 		inbound_qty: 'Số Lượng Nhập Kho', // Inbound Quantity
@@ -13,6 +16,8 @@ export default {
 		kg_noend: 'Thứ tự thùng cuối',
 		kg_nostart: 'Thứ tự thùng đầu',
 		mat_code: 'Mã thành phẩm',
+		mat_ecolor: 'Màu sắc sản phẩm',
+		missing_qty: 'Số lượng còn thiếu',
 		mo_no: 'Chỉ lệnh',
 		mo_no_actual: 'Chỉ lệnh thực',
 		no_crates_in_stock: 'Số thùng nhập kho',
@@ -50,8 +55,7 @@ export default {
 		status_approve: 'Trạng thái duyệt đơn',
 		trans_num: 'Lượng thùng đã phát',
 		transfer_order_code: 'Mã đơn chuyển giao',
-		uninspected_qty: 'Số Lượng Chưa Kiểm Tra', // Uninspected Quantity
-		employee_name: 'Nhân viên tạo đơn'
+		uninspected_qty: 'Số Lượng Chưa Kiểm Tra' // Uninspected Quantity
 	},
 	inventory_list_type: {
 		finished_goods_dispatch: 'Đơn xuất kho thành phẩm',


### PR DESCRIPTION
This pull request includes significant updates to the `ReportDatalist` component, various UI components, and internationalization files. The main changes involve adding new features to the report data list, enhancing the table components, and updating language translations.

Enhancements to the `ReportDatalist` component:

* Added new columns and modified existing ones, including `ROW_EXPANSION_COLUMN_ID`, `mat_ecolor`, `shaping_dept_name`, `daily_inbound_qty`, `accumulated_inbound_qty`, and `missing_qty` in `src/app/(features)/_layout.inbound-report/_components/-report-datalist.tsx` [[1]](diffhunk://#diff-17dc0be56c716677a65615129ed5712842f9dfd561ee4d500d4db08660367adcR56-R80) [[2]](diffhunk://#diff-17dc0be56c716677a65615129ed5712842f9dfd561ee4d500d4db08660367adcL61-R125) [[3]](diffhunk://#diff-17dc0be56c716677a65615129ed5712842f9dfd561ee4d500d4db08660367adcL87-R168).
* Implemented row expansion functionality and added a sub-component `InboundReportDetailTable` to display detailed information in `src/app/(features)/_layout.inbound-report/_components/-report-datalist.tsx` [[1]](diffhunk://#diff-17dc0be56c716677a65615129ed5712842f9dfd561ee4d500d4db08660367adcR190-R196) [[2]](diffhunk://#diff-17dc0be56c716677a65615129ed5712842f9dfd561ee4d500d4db08660367adcR218-R255).
* Changed the file naming convention for the downloaded report to use the search parameter date in `src/app/(features)/_layout.inbound-report/_components/-report-datalist.tsx`.

Enhancements to UI components:

* Updated the table component to include rounded borders and improved shadow effects in `src/components/ui/@core/table.tsx` and `src/components/ui/@react-table/components/table-body.tsx` [[1]](diffhunk://#diff-846b2bea9a3f5b0a893699e14723df5e88a3b29eb28b4c598de0f767c8000f93L10-R10) [[2]](diffhunk://#diff-7614e50b5e6bb61aee19b1c0a2f8326f6d45b3ea3374b0c88880c0921d819d09L73-L84).
* Added a new typography variant `warning` in `src/components/ui/@custom/typography.tsx`.
* Enhanced the `TableDataGrid` component to use dynamic sizing and added a log statement in `src/components/ui/@react-table/components/table.tsx` [[1]](diffhunk://#diff-e3f7c9824cea867324b1c84ebdd3a24e644796e173649c245bea675abf01df19L69-R74) [[2]](diffhunk://#diff-e3f7c9824cea867324b1c84ebdd3a24e644796e173649c245bea675abf01df19R95-R103).

Updates to internationalization files:

* Added new translation keys for fields such as `accumulated_inbound_qty`, `daily_inbound_qty`, `mat_ecolor`, and `missing_qty` across multiple language files including Chinese, English, and Vietnamese in `src/i18n/cn/ns_erp.i18n.ts`, `src/i18n/en/ns_erp.i18n.ts`, and `src/i18n/vi/ns_erp.i18n.ts` [[1]](diffhunk://#diff-9df286eea6fc4e482ed86b636fa81f0dbd203645b8139296901eb3a439aba70cR3-R9) [[2]](diffhunk://#diff-849cb63abbd68c7fba2e62aef0408bf051a9b12a56aebd2e8e4179b0b4e06836R3-R9) [[3]](diffhunk://#diff-061b5e6156c66cf0fd576ab0c34b847d502cbd13b7ba73f0c5818d9bb91b7fa1R3-R20).
* Added the translation for the action `fold` in `src/i18n/cn/ns_common.i18n.ts`, `src/i18n/en/ns_common.i18n.ts`, and `src/i18n/vi/ns_common.i18n.ts` [[1]](diffhunk://#diff-63e90a5003f58464d987b6d8f06b10f21cee3bef90280d2b143740da24f77d6cR20) [[2]](diffhunk://#diff-cc7039618120b2a2ab10d832636743dc84a38459f45d63655d1c893ec45d8803R20) [[3]](diffhunk://#diff-ba7bffb00d684380f574e63bd09b5f4f072683c418735e088c6b8fbe5714ac1dR19).