### PR TITLE
Fix/outbound report

### DIFF
--- a/src/app/(features)/_layout.outbound-report/_components/-report-detail-row.tsx
+++ b/src/app/(features)/_layout.outbound-report/_components/-report-detail-row.tsx
@@ -20,9 +20,6 @@ export const ReportDetailRow: React.FC<{ data: IOutboundReport['detail'][number]
 			<TableCell className='group/cell sticky left-0 z-10 w-[var(--sticky-left-col-width)] min-w-[var(--sticky-left-col-width)] space-y-1 text-center'>
 				<Div className='flex items-center gap-x-2'>{data?.mo_no}</Div>
 			</TableCell>
-			<TableCell className='sticky left-[var(--sticky-left-col-width)] z-10 w-[var(--sticky-left-col-width)] min-w-[var(--sticky-left-col-width)] border-r-0 drop-shadow-[1px_0px_hsl(var(--border))]'>
-				{data?.mat_ecolor}
-			</TableCell>
 			<TableCell className={cn('!p-0')}>
 				<Div
 					className='flex flex-grow border-collapse flex-nowrap divide-x'

--- a/src/app/(features)/_layout.outbound-report/_components/-report-detail-row.tsx
+++ b/src/app/(features)/_layout.outbound-report/_components/-report-detail-row.tsx
@@ -1,0 +1,48 @@
+import { IOutboundReport } from '@/common/types/entities'
+import { cn } from '@/common/utils/cn'
+import { Div, TableCell, TableRow } from '@/components/ui'
+import { sortBy } from 'lodash'
+import { useMemo } from 'react'
+
+export const ReportDetailRow: React.FC<{ data: IOutboundReport['detail'][number] }> = ({ data }) => {
+	const aggregateSizeCount = useMemo(
+		() =>
+			Array.isArray(data?.sizes)
+				? data.sizes.reduce((acc, curr) => {
+						return acc + curr.qty
+					}, 0)
+				: 0,
+		[data]
+	)
+
+	return (
+		<TableRow>
+			<TableCell className='group/cell sticky left-0 z-10 w-[var(--sticky-left-col-width)] min-w-[var(--sticky-left-col-width)] space-y-1 text-center'>
+				<Div className='flex items-center gap-x-2'>{data?.mo_no}</Div>
+			</TableCell>
+			<TableCell className='sticky left-[var(--sticky-left-col-width)] z-10 w-[var(--sticky-left-col-width)] min-w-[var(--sticky-left-col-width)] border-r-0 drop-shadow-[1px_0px_hsl(var(--border))]'>
+				{data?.mat_ecolor}
+			</TableCell>
+			<TableCell className={cn('!p-0')}>
+				<Div
+					className='flex flex-grow border-collapse flex-nowrap divide-x'
+					onContextMenu={(e) => e.preventDefault()}>
+					{Array(data?.sizes) &&
+						sortBy(data.sizes, 'size_numcode').map((size) => (
+							<Div
+								key={size?.size_numcode}
+								className='group/cell inline-grid min-w-28 shrink-0 basis-28 grid-rows-2 divide-y last:flex-1'>
+								<TableCell className='bg-table-head font-medium'>
+									<Div className='flex items-center gap-x-2'>{size?.size_numcode}</Div>
+								</TableCell>
+								<TableCell>{size?.qty ?? 0}</TableCell>
+							</Div>
+						))}
+				</Div>
+			</TableCell>
+			<TableCell align='right' className='sticky right-0 w-24 min-w-24 font-medium'>
+				{aggregateSizeCount}
+			</TableCell>
+		</TableRow>
+	)
+}

--- a/src/app/(features)/_layout.outbound-report/_components/-report-detail-table.tsx
+++ b/src/app/(features)/_layout.outbound-report/_components/-report-detail-table.tsx
@@ -10,7 +10,7 @@ const OutboundReportDetailTable: React.FC<{ data: IOutboundReport['detail'] }> =
 
 	return (
 		<Div className='relative flex flex-col divide-y overflow-hidden rounded-lg border'>
-			<Div className='max-h-[50vh] overflow-scroll'>
+			<Div className='max-h-[40vh] overflow-scroll'>
 				<Table
 					className='border-separate border-spacing-0 rounded-lg'
 					style={
@@ -21,7 +21,7 @@ const OutboundReportDetailTable: React.FC<{ data: IOutboundReport['detail'] }> =
 						} as React.CSSProperties
 					}>
 					<TableHeader className='sticky top-0 z-20'>
-						<TableRow className='sticky *:bg-table-head'>
+						<TableRow className='sticky'>
 							<TableHead className='left-0 z-20 w-[var(--sticky-left-col-width)] min-w-[var(--sticky-left-col-width)] whitespace-nowrap xl:sticky'>
 								{t('ns_erp:fields.mo_no')}
 							</TableHead>

--- a/src/app/(features)/_layout.outbound-report/_components/-report-detail-table.tsx
+++ b/src/app/(features)/_layout.outbound-report/_components/-report-detail-table.tsx
@@ -1,5 +1,5 @@
 import { IOutboundReport } from '@/common/types/entities'
-import { Div, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui'
+import { Div, Icon, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui'
 import { useTranslation } from 'react-i18next'
 import { ReportDetailRow } from './-report-detail-row'
 
@@ -25,9 +25,6 @@ const OutboundReportDetailTable: React.FC<{ data: IOutboundReport['detail'] }> =
 							<TableHead className='left-0 z-20 w-[var(--sticky-left-col-width)] min-w-[var(--sticky-left-col-width)] whitespace-nowrap xl:sticky'>
 								{t('ns_erp:fields.mo_no')}
 							</TableHead>
-							<TableHead className='left-[var(--sticky-left-col-width)] z-20 w-[var(--sticky-left-col-width)] min-w-[var(--sticky-left-col-width)] whitespace-nowrap xl:sticky'>
-								{t('ns_erp:fields.mat_ecolor')}
-							</TableHead>
 							<TableHead>Size</TableHead>
 							<TableHead className='right-0 z-20 w-32 bg-background xl:sticky'>
 								{t('ns_common:common_fields.total')}
@@ -40,7 +37,10 @@ const OutboundReportDetailTable: React.FC<{ data: IOutboundReport['detail'] }> =
 						) : (
 							<TableRow>
 								<TableCell align='center' colSpan={4} className='p-20 text-muted-foreground'>
-									{t('ns_common:table.no_data')}
+									<Div className='inline-flex items-center justify-center gap-x-2'>
+										<Icon name='Inbox' size={24} strokeWidth={1} />
+										{t('ns_common:table.no_data')}
+									</Div>
 								</TableCell>
 							</TableRow>
 						)}

--- a/src/app/(features)/_layout.outbound-report/_components/-report-detail-table.tsx
+++ b/src/app/(features)/_layout.outbound-report/_components/-report-detail-table.tsx
@@ -1,40 +1,52 @@
 import { IOutboundReport } from '@/common/types/entities'
-import formatIntlNumber from '@/common/utils/format-intl-number'
 import { Div, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui'
 import { useTranslation } from 'react-i18next'
+import { ReportDetailRow } from './-report-detail-row'
 
-const OutboundReportDetailTable: React.FC<{ data: IOutboundReport['size_data'] }> = ({ data }) => {
+const OutboundReportDetailTable: React.FC<{ data: IOutboundReport['detail'] }> = ({ data }) => {
+	console.log(data)
+
 	const { t } = useTranslation()
 
 	return (
-		<Div className='w-1/4 overflow-clip rounded-md border'>
-			<Table className='table-fixed !border-none'>
-				<TableHeader>
-					<TableRow>
-						<TableHead>Size</TableHead>
-						<TableHead>{t('ns_erp:fields.inbound_qty')}</TableHead>
-					</TableRow>
-				</TableHeader>
-				<TableBody>
-					{Array.isArray(data) && data.length > 0 ? (
-						data.map((item) => (
-							<TableRow key={item.size_numcode}>
-								<TableCell align='center' className='font-medium'>
-									{item.size_numcode}
-								</TableCell>
-								<TableCell align='center'>{formatIntlNumber(item.qty)}</TableCell>
-								{data.length === 0 && <TableCell></TableCell>}
-							</TableRow>
-						))
-					) : (
-						<TableRow>
-							<TableCell align='center' colSpan={2} className='font-medium'>
-								{t('ns_common:table.no_data')}
-							</TableCell>
+		<Div className='relative flex flex-col divide-y overflow-hidden rounded-lg border'>
+			<Div className='max-h-[50vh] overflow-scroll'>
+				<Table
+					className='border-separate border-spacing-0 rounded-lg'
+					style={
+						{
+							'--row-selection-col-width': '3rem',
+							'--sticky-left-col-width': '10rem',
+							'--row-action-col-width': '5rem'
+						} as React.CSSProperties
+					}>
+					<TableHeader className='sticky top-0 z-20'>
+						<TableRow className='sticky *:bg-table-head'>
+							<TableHead className='left-0 z-20 w-[var(--sticky-left-col-width)] min-w-[var(--sticky-left-col-width)] whitespace-nowrap xl:sticky'>
+								{t('ns_erp:fields.mo_no')}
+							</TableHead>
+							<TableHead className='left-[var(--sticky-left-col-width)] z-20 w-[var(--sticky-left-col-width)] min-w-[var(--sticky-left-col-width)] whitespace-nowrap xl:sticky'>
+								{t('ns_erp:fields.mat_ecolor')}
+							</TableHead>
+							<TableHead>Size</TableHead>
+							<TableHead className='right-0 z-20 w-32 bg-background xl:sticky'>
+								{t('ns_common:common_fields.total')}
+							</TableHead>
 						</TableRow>
-					)}
-				</TableBody>
-			</Table>
+					</TableHeader>
+					<TableBody>
+						{Array.isArray(data) && data.length > 0 ? (
+							data.map((item) => <ReportDetailRow key={item.mo_no} data={item} />)
+						) : (
+							<TableRow>
+								<TableCell align='center' colSpan={4} className='p-20 text-muted-foreground'>
+									{t('ns_common:table.no_data')}
+								</TableCell>
+							</TableRow>
+						)}
+					</TableBody>
+				</Table>
+			</Div>
 		</Div>
 	)
 }

--- a/src/app/(features)/_layout.outbound-report/_components/-report-master-table.tsx
+++ b/src/app/(features)/_layout.outbound-report/_components/-report-master-table.tsx
@@ -74,6 +74,15 @@ const ReportDatalist: React.FC = () => {
 				filterFn: 'fuzzy',
 				cell: ({ getValue }) => getValue() ?? 'Unknown'
 			}),
+			columnHelper.accessor('mat_ecolor', {
+				header: t('ns_erp:fields.mat_ecolor'),
+				enableColumnFilter: true,
+				enableSorting: true,
+				enablePinning: true,
+				minSize: 200,
+				filterFn: 'fuzzy',
+				cell: ({ getValue }) => getValue() ?? 'Unknown'
+			}),
 			columnHelper.accessor('order_qty', {
 				header: t('ns_erp:fields.order_qty'),
 				enableColumnFilter: true,

--- a/src/app/(features)/_layout.outbound-report/_components/-report-master-table.tsx
+++ b/src/app/(features)/_layout.outbound-report/_components/-report-master-table.tsx
@@ -6,7 +6,7 @@ import useMediaQuery from '@/common/hooks/use-media-query'
 import useQueryParams from '@/common/hooks/use-query-params'
 import { IOutboundReport } from '@/common/types/entities'
 import formatIntlNumber from '@/common/utils/format-intl-number'
-import { Button, DataTable, Div, Icon, Tooltip } from '@/components/ui'
+import { Button, DataTable, Div, Icon, Separator, Tooltip, Typography } from '@/components/ui'
 import { ROW_EXPANSION_COLUMN_ID } from '@/components/ui/@react-table/constants'
 import { ReportService } from '@/services/report.service'
 import { createColumnHelper } from '@tanstack/react-table'
@@ -145,7 +145,7 @@ const ReportDatalist: React.FC = () => {
 
 	return (
 		<Div as='section' className='relative'>
-			<Div className='absolute left-0 top-0'>
+			<Div aria-description='Auto refresh toggle' className='absolute left-0 top-0'>
 				<AutoRefreshToggle />
 			</Div>
 			<DataTable
@@ -153,9 +153,6 @@ const ReportDatalist: React.FC = () => {
 				data={data}
 				loading={isLoading}
 				enableExpanding={true}
-				containerProps={{
-					style: { height: screen.availHeight / 1.75 }
-				}}
 				renderSubComponent={({ row }) => {
 					return <OutboundReportDetailTable data={row.original.detail} />
 				}}
@@ -178,6 +175,25 @@ const ReportDatalist: React.FC = () => {
 								</Button>
 							</Tooltip>
 						</Fragment>
+					)
+				}}
+				footerProps={{
+					slot: () => (
+						<Div
+							role='row'
+							aria-colspan={columns.length}
+							className='flex w-full items-center justify-center gap-x-4'>
+							<Typography color='muted' className='font-medium'>
+								{t('ns_common:common_fields.total')}
+							</Typography>
+							<Separator orientation='horizontal' className='h-0.5 basis-4' />
+							<Typography className='inline-flex items-baseline gap-x-1 font-medium'>
+								{Array.isArray(data)
+									? formatIntlNumber(data?.reduce((acc, curr) => acc + curr.daily_outbound_qty, 0))
+									: 0}
+								<Typography variant='small'>pcs</Typography>
+							</Typography>
+						</Div>
 					)
 				}}
 			/>

--- a/src/app/(features)/_layout.outbound-report/_components/-report-master-table.tsx
+++ b/src/app/(features)/_layout.outbound-report/_components/-report-master-table.tsx
@@ -12,7 +12,6 @@ import { ReportService } from '@/services/report.service'
 import { createColumnHelper } from '@tanstack/react-table'
 import { format } from 'date-fns'
 import { saveAs } from 'file-saver'
-import { capitalize } from 'lodash'
 import { Fragment, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -66,14 +65,6 @@ const ReportDatalist: React.FC = () => {
 				minSize: 150,
 				filterFn: 'fuzzy'
 			}),
-			columnHelper.accessor('mo_no', {
-				header: t('ns_erp:fields.mo_no'),
-				enableColumnFilter: true,
-				enableSorting: true,
-				enablePinning: true,
-				minSize: 150,
-				filterFn: 'fuzzy'
-			}),
 			columnHelper.accessor('shoes_style_code_factory', {
 				header: t('ns_erp:fields.shoestyle_codefactory'),
 				enableColumnFilter: true,
@@ -82,19 +73,6 @@ const ReportDatalist: React.FC = () => {
 				minSize: 200,
 				filterFn: 'fuzzy',
 				cell: ({ getValue }) => getValue() ?? 'Unknown'
-			}),
-			columnHelper.accessor('mat_ecolor', {
-				header: t('ns_erp:fields.mat_ecolor'),
-				enableColumnFilter: true,
-				enableSorting: true,
-				enablePinning: true,
-				filterFn: 'fuzzy',
-				minSize: 200,
-				cell: ({ getValue }) => {
-					const value = getValue()
-					if (value) return capitalize(value)
-					return 'Unknown'
-				}
 			}),
 			columnHelper.accessor('order_qty', {
 				header: t('ns_erp:fields.order_qty'),
@@ -125,7 +103,6 @@ const ReportDatalist: React.FC = () => {
 				cell: ({ getValue }) => formatIntlNumber(getValue()),
 				minSize: 250
 			}),
-
 			columnHelper.accessor('missing_qty', {
 				header: t('ns_erp:fields.missing_qty'),
 				enableColumnFilter: true,
@@ -171,7 +148,7 @@ const ReportDatalist: React.FC = () => {
 					style: { height: screen.availHeight / 1.75 }
 				}}
 				renderSubComponent={({ row }) => {
-					return <OutboundReportDetailTable data={row.original?.size_data} />
+					return <OutboundReportDetailTable data={row.original.detail} />
 				}}
 				toolbarProps={{
 					slotLeft: () => isSmallScreen && <DatePickerFilter />,

--- a/src/common/types/entities.d.ts
+++ b/src/common/types/entities.d.ts
@@ -98,10 +98,18 @@ export interface IInboundReport extends IInOutBoundReport {
 	storage: string
 	daily_inbound_qty: number
 }
-export interface IOutboundReport extends IInOutBoundReport {
+export interface IOutboundReport extends Omit<IInOutBoundReport, 'size_data'> {
 	po: string
 	missing_qty: number
 	daily_outbound_qty: number
+	detail: Array<{
+		mo_no: string
+		mat_ecolor: string
+		sizes: Array<{
+			size_numcode: string
+			qty: number
+		}>
+	}>
 }
 
 export interface IMonthlyInventoryReport {

--- a/src/components/shared/loading.tsx
+++ b/src/components/shared/loading.tsx
@@ -1,6 +1,8 @@
+import AppLogo from '@/app/_components/_shared/-app-logo'
 import { useEventListener } from 'ahooks'
 import nProgress from 'nprogress'
 import { useEffect } from 'react'
+import { Div } from '../ui'
 
 export default function Loading() {
 	nProgress.configure({
@@ -16,5 +18,11 @@ export default function Loading() {
 
 	useEventListener('load', () => document.startViewTransition())
 
-	return null
+	return (
+		<Div data-state='expanded' className='group grid h-screen place-content-center'>
+			<Div className='animate-[fade-in_.125s_cubic-bezier(.25,.25,0,1)_.25s_both!important]'>
+				<AppLogo />
+			</Div>
+		</Div>
+	)
 }

--- a/src/services/report.service.ts
+++ b/src/services/report.service.ts
@@ -1,5 +1,5 @@
 import { RequestHeaders } from '@/common/constants/enums'
-import { IInboundReport, IMonthlyInventoryReport, IPackingReport } from '@/common/types/entities'
+import { IInboundReport, IMonthlyInventoryReport, IOutboundReport, IPackingReport } from '@/common/types/entities'
 import axiosInstance from '@/configs/axios.config'
 import { AxiosRequestConfig } from 'axios'
 
@@ -12,7 +12,7 @@ export class ReportService {
 	}
 
 	static async getOutboundReport(tenantId: string, params?: { 'date.eq': string }) {
-		return await axiosInstance.get<void, ResponseBody<IInboundReport[]>>('/report/daily-outbound', {
+		return await axiosInstance.get<void, ResponseBody<IOutboundReport[]>>('/report/daily-outbound', {
 			headers: { [RequestHeaders.TENANT_ID]: tenantId },
 			params: params
 		})


### PR DESCRIPTION
This pull request includes several changes to the outbound report feature, focusing on adding new components, modifying existing ones, and updating the report service. The most important changes include the addition of the `ReportDetailRow` component, updates to the `OutboundReportDetailTable` component, and modifications to the `ReportMasterTable` component.

### New Components:
* Added `ReportDetailRow` component to display detailed information for each report row. (`src/app/(features)/_layout.outbound-report/_components/-report-detail-row.tsx`)

### Component Updates:
* Updated `OutboundReportDetailTable` to use the new `ReportDetailRow` component, improving the structure and styling of the table. (`src/app/(features)/_layout.outbound-report/_components/-report-detail-table.tsx`)
* Modified `ReportMasterTable` to include additional UI elements such as a footer and improved the rendering of subcomponents. (`src/app/(features)/_layout.outbound-report/_components/-report-master-table.tsx`) [[1]](diffhunk://#diff-490b68219a8b0506558fa32af19058a01d4ba103d92a687332a9d5581cb2a7cdL69-L76) [[2]](diffhunk://#diff-490b68219a8b0506558fa32af19058a01d4ba103d92a687332a9d5581cb2a7cdL91-R84) [[3]](diffhunk://#diff-490b68219a8b0506558fa32af19058a01d4ba103d92a687332a9d5581cb2a7cdL128) [[4]](diffhunk://#diff-490b68219a8b0506558fa32af19058a01d4ba103d92a687332a9d5581cb2a7cdL162-R157) [[5]](diffhunk://#diff-490b68219a8b0506558fa32af19058a01d4ba103d92a687332a9d5581cb2a7cdR180-R198)

### Service Updates:
* Updated the `ReportService` to include a method for fetching outbound reports. (`src/services/report.service.ts`) [[1]](diffhunk://#diff-0bab4fabf48a544eb18848d7552b10f318c95124161ebdcd3682b07fb5e72fbaL2-R2) [[2]](diffhunk://#diff-0bab4fabf48a544eb18848d7552b10f318c95124161ebdcd3682b07fb5e72fbaL15-R15)

### Miscellaneous:
* Enhanced the loading component to display an animated logo during loading states. (`src/components/shared/loading.tsx`) [[1]](diffhunk://#diff-405d651e9bc090aa6a80ca626b8fb3277685efbf597460df117691ae58b5e994R1-R5) [[2]](diffhunk://#diff-405d651e9bc090aa6a80ca626b8fb3277685efbf597460df117691ae58b5e994L19-R27)