### PR TITLE
Fix/signature editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
 		"@tiptap/pm": "^3.2.0",
 		"@tiptap/react": "^3.1.0",
 		"@tiptap/starter-kit": "^3.1.0",
-		"@uiw/react-signature": "^1.3.3",
 		"@yudiel/react-qr-scanner": "^2.4.1",
 		"ahooks": "^3.8.4",
 		"axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
 		"react-hook-form": "^7.54.2",
 		"react-i18next": "^15.4.1",
 		"react-resizable-panels": "^2.1.7",
+		"react-signature-canvas": "1.1.0-alpha.2",
 		"recharts": "^2.15.1",
 		"socket.io-client": "^4.8.1",
 		"sonner": "^1.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       react-resizable-panels:
         specifier: ^2.1.7
         version: 2.1.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react-signature-canvas:
+        specifier: 1.1.0-alpha.2
+        version: 1.1.0-alpha.2(@types/react@19.2.7)(prop-types@15.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       recharts:
         specifier: ^2.15.1
         version: 2.15.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -3498,6 +3501,9 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@types/signature_pad@2.3.6':
+    resolution: {integrity: sha512-v3j92gCQJoxomHhd+yaG4Vsf8tRS/XbzWKqDv85UsqjMGy4zhokuwKe4b6vhbgncKkh+thF+gpz6+fypTtnFqQ==}
+
   '@types/statuses@2.0.5':
     resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
 
@@ -6443,6 +6449,20 @@ packages:
       react-router-dom:
         optional: true
 
+  react-signature-canvas@1.1.0-alpha.2:
+    resolution: {integrity: sha512-tKUNk3Gmh04Ug4K8p5g8Is08BFUKvbXxi0PyetQ/f8OgCBzcx4vqNf9+OArY/TdNdfHtswXQNRwZD6tyELjkjQ==}
+    peerDependencies:
+      '@types/prop-types': ^15.7.3
+      '@types/react': 0.14 - 19
+      prop-types: ^15.5.8
+      react: 0.14 - 19
+      react-dom: 0.14 - 19
+    peerDependenciesMeta:
+      '@types/prop-types':
+        optional: true
+      '@types/react':
+        optional: true
+
   react-smooth@4.0.4:
     resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
@@ -6781,6 +6801,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  signature_pad@2.3.2:
+    resolution: {integrity: sha512-peYXLxOsIY6MES2TrRLDiNg2T++8gGbpP2yaC+6Ohtxr+a2dzoaqWosWDY9sWqTAAk6E/TyQO+LJw9zQwyu5kA==}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -7157,6 +7180,9 @@ packages:
   tr46@5.0.0:
     resolution: {integrity: sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==}
     engines: {node: '>=18'}
+
+  trim-canvas@0.1.2:
+    resolution: {integrity: sha512-nd4Ga3iLFV94mdhW9JFMLpQbHUyCQuhFOD71PEAt1NjtMD5wbZctzhX8c3agHNybMR5zXD1XTGoIEWk995E6pQ==}
 
   ts-api-utils@2.0.1:
     resolution: {integrity: sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==}
@@ -10981,6 +11007,8 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@types/signature_pad@2.3.6': {}
+
   '@types/statuses@2.0.5': {}
 
   '@types/tough-cookie@4.0.5': {}
@@ -14180,6 +14208,18 @@ snapshots:
       - rollup
       - supports-color
 
+  react-signature-canvas@1.1.0-alpha.2(@types/react@19.2.7)(prop-types@15.8.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@types/signature_pad': 2.3.6
+      prop-types: 15.8.1
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      signature_pad: 2.3.2
+      trim-canvas: 0.1.2
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   react-smooth@4.0.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       fast-equals: 5.2.2
@@ -14588,6 +14628,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  signature_pad@2.3.2: {}
 
   simple-concat@1.0.1: {}
 
@@ -15024,6 +15066,8 @@ snapshots:
   tr46@5.0.0:
     dependencies:
       punycode: 2.3.1
+
+  trim-canvas@0.1.2: {}
 
   ts-api-utils@2.0.1(typescript@5.7.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,9 +188,6 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.1.0
         version: 3.1.0
-      '@uiw/react-signature':
-        specifier: ^1.3.3
-        version: 1.3.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@yudiel/react-qr-scanner':
         specifier: ^2.4.1
         version: 2.4.1(@types/emscripten@1.41.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -3569,12 +3566,6 @@ packages:
     resolution: {integrity: sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@uiw/react-signature@1.3.3':
-    resolution: {integrity: sha512-TzsMSN6AWgfCMoxmZMMtuDQ9GwlZJ0C5inR3s2qGusV6OKP5s1Nf2QPhdZBjd6ZfTsjA41d16tbFzG6QvWze4g==}
-    peerDependencies:
-      react: '>=16.9.0'
-      react-dom: '>=16.9.0'
-
   '@vite-pwa/assets-generator@0.2.6':
     resolution: {integrity: sha512-kK44dXltvoubEo5B+6tCGjUrOWOE1+dA4DForbFpO1rKy2wSkAVGrs8tyfN6DzTig89/QKyV8XYodgmaKyrYng==}
     engines: {node: '>=16.14.0'}
@@ -6022,9 +6013,6 @@ packages:
   pbkdf2@3.1.3:
     resolution: {integrity: sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==}
     engines: {node: '>=0.12'}
-
-  perfect-freehand@1.2.2:
-    resolution: {integrity: sha512-eh31l019WICQ03pkF3FSzHxB8n07ItqIQ++G5UV8JX0zVOXzgTGCqnRR0jJ2h9U8/2uW4W4mtGJELt9kEV0CFQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -11100,13 +11088,6 @@ snapshots:
       '@typescript-eslint/types': 8.24.1
       eslint-visitor-keys: 4.2.0
 
-  '@uiw/react-signature@1.3.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      perfect-freehand: 1.2.2
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
-
   '@vite-pwa/assets-generator@0.2.6':
     dependencies:
       cac: 6.7.14
@@ -13796,8 +13777,6 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
       to-buffer: 1.2.1
-
-  perfect-freehand@1.2.2: {}
 
   picocolors@1.1.1: {}
 

--- a/src/app/(features)/_layout.truckload-delivery/-components/signature-editor-dialog.tsx
+++ b/src/app/(features)/_layout.truckload-delivery/-components/signature-editor-dialog.tsx
@@ -25,11 +25,12 @@ import {
 	Typography
 } from '@/components/ui'
 import { ITruckloadDelivery } from '@/services/truckload-delivery.service'
-import Signature, { StrokeOptions } from '@uiw/react-signature'
+import { StrokeOptions } from '@uiw/react-signature'
 import { useDebounce, useRafState, useResetState } from 'ahooks'
 import { debounce } from 'lodash-es'
 import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import SignatureCanvas from 'react-signature-canvas'
 import { toast } from 'sonner'
 import { TruckloadDeliveryStatus } from '../-constants'
 import { SignatureType, usePageContext } from '../-contexts/page-context'
@@ -272,7 +273,13 @@ const SignatureEditorDialog: React.FC = () => {
 							aria-invalid={isMissingSignature}
 							className='relative max-h-full min-h-[50vh] flex-1 basis-full overflow-clip rounded-md border duration-200 aria-[readonly=true]:!border aria-[invalid=true]:border-destructive hover:border-primary aria-[invalid=true]:hover:border-destructive aria-[readonly=true]:hover:border-border'>
 							{isCompressing && <OptimizingLoader />}
-							<Signature
+							<SignatureCanvas
+								penColor='black'
+								ref={$svg}
+								canvasProps={{ className: 'sigCanvas' }}
+								onBegin={(e) => console.log(e)}
+							/>
+							{/* <Signature
 								ref={$svg}
 								fill='hsl(var(--foreground))'
 								className='aria-readonly:cursor-not-allowed'
@@ -297,7 +304,7 @@ const SignatureEditorDialog: React.FC = () => {
 										easing: (t) => t
 									}
 								}}
-							/>
+							/> */}
 						</Div>
 						{isMissingSignature && (
 							<Typography variant='small' color='destructive' className='font-medium'>

--- a/src/app/(features)/_layout.truckload-delivery/-components/signature-editor-dialog.tsx
+++ b/src/app/(features)/_layout.truckload-delivery/-components/signature-editor-dialog.tsx
@@ -1,9 +1,6 @@
-import useMediaQuery from '@/common/hooks/use-media-query'
 import { useReactiveRef } from '@/common/hooks/use-reactive-ref'
 import { useWorkerFn } from '@/common/hooks/use-worker-fn'
 import compressBase64 from '@/common/libs/compress-base64'
-import { convertSvgToWebp } from '@/common/libs/convert-webp'
-import { svgToOptimizedBase64 } from '@/common/libs/optimize-svg'
 import {
 	Button,
 	Dialog,
@@ -25,10 +22,8 @@ import {
 	Typography
 } from '@/components/ui'
 import { ITruckloadDelivery } from '@/services/truckload-delivery.service'
-import { StrokeOptions } from '@uiw/react-signature'
-import { useDebounce, useRafState, useResetState } from 'ahooks'
-import { debounce } from 'lodash-es'
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { useResetState } from 'ahooks'
+import React, { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import SignatureCanvas from 'react-signature-canvas'
 import { toast } from 'sonner'
@@ -38,11 +33,7 @@ import { useUpdateDispatchOrderSignatureMutation } from '../-hooks/use-truckload
 
 const SignatureEditorDialog: React.FC = () => {
 	const { t } = useTranslation()
-	const $svg = useRef(null)
 	const [open, setOpen] = useResetState<boolean>(false)
-	const [points, setPoints] = useRafState([])
-	const [base64ImageFormat, setBase64ImageFormat] = useResetState<'svg' | 'webp' | null>('webp')
-	const isMobile = useMediaQuery('(max-width: 1279px)')
 	const { mutateAsync: setStatusAsync, isPending, isError } = useUpdateDispatchOrderSignatureMutation()
 	const [statusToUpdate, setStatusToUpdate] = useState<
 		TruckloadDeliveryStatus.CONFIRMED | TruckloadDeliveryStatus.REQUEST_CHANGE
@@ -61,8 +52,8 @@ const SignatureEditorDialog: React.FC = () => {
 		license_plate: null,
 		signature_type: null
 	})
-
-	const debouncedPoints = useDebounce(points, { wait: 200, leading: false, trailing: true })
+	const canvasRef = useRef<SignatureCanvas>(null)
+	const isEmpty = useReactiveRef<boolean>(canvasRef.current?.isEmpty() ?? true)
 
 	event$.useSubscription(({ action, payload }) => {
 		if (action === 'UPDATE_DISPATCH_ORDER_SIGNATURE') {
@@ -79,109 +70,28 @@ const SignatureEditorDialog: React.FC = () => {
 
 	const { execute: compress, isPending: isCompressing } = useWorkerFn(compressBase64)
 
-	const handlePoints = useCallback(
-		debounce(
-			(data) => {
-				if (data.length > 0) {
-					setPoints((prev) => [...prev, JSON.stringify(data)])
-				}
-			},
-			1000,
-			{ leading: false, trailing: true }
-		),
-		[setPoints]
-	)
-
-	const signatureOptions = useMemo<StrokeOptions>(
-		() => ({
-			size: 6,
-			smoothing: isMobile ? 0.25 : 0.5,
-			thinning: 0.1,
-			streamline: isMobile ? 0 : 0.9,
-			simulatePressure: true,
-			easing(pressure) {
-				return pressure <= 0.5 ? 16 * pressure ** 5 : 1 + 16 * (--pressure) ** 5
-			},
-			start: {
-				taper: 0,
-				cap: true
-			},
-			end: {
-				taper: 0,
-				cap: true
-			}
-		}),
-		[isMobile]
-	)
-
-	const signatureStyle = useMemo(
-		() =>
-			({
-				'--w-signature-background': 'hsl(var(--background))'
-			}) as React.CSSProperties,
-		[]
-	)
-
-	const handleBase64SvgImage = useCallback(async () => {
-		if (!debouncedPoints.length || !$svg.current?.svg) return
-
-		const svgElement = $svg.current.svg
-
-		// Setup SVG attributes
-		const svgClone = svgElement.cloneNode(true) as SVGSVGElement
-		const clientWidth = svgElement.clientWidth || 300
-		const clientHeight = svgElement.clientHeight || 200
-
-		svgClone.removeAttribute('style')
-		svgClone.setAttribute('width', `${clientWidth}px`)
-		svgClone.setAttribute('height', `${clientHeight}px`)
-		svgClone.setAttribute('viewBox', `0 0 ${clientWidth} ${clientHeight}`)
-		svgClone.setAttribute('fill', '#0a0a0a')
-
-		const optimizedBase64 = svgToOptimizedBase64(svgClone, {
-			removeUnusedAttrs: true,
-			removeComments: true,
-			minifyPathData: true,
-			decimalPrecision: 2
-		})
-
-		return optimizedBase64
-	}, [debouncedPoints])
-
-	const handleBase64PngImage = useCallback(async () => {
-		if (!debouncedPoints.length) return
-
-		const pngBase64 = await convertSvgToWebp($svg.current?.svg, {
-			backgroundColor: 'transparent',
-			fillColor: '#0a0a0a',
-			quality: 1.0
-		})
-
-		const compressedBase64 = await compress(pngBase64, {
-			type: 'image/webp',
-			width: 300,
-			height: 200,
-			max: 20, // Max 50KB
-			quality: 1
-		})
-
-		return compressedBase64
-	}, [debouncedPoints, compress])
+	const isMissingSignature = isEmpty.current && isSubmitted
 
 	const handleSignSignature = async () => {
 		setIsSubmitted(true)
+		if (isEmpty.current) return
+		toast.loading(t('ns_common:notification.processing_request'), { id: 'update_signature' })
 		try {
-			const optimizedBase64 =
-				base64ImageFormat === 'svg' ? await handleBase64SvgImage() : await handleBase64PngImage()
-			if (!optimizedBase64) return
-
-			toast.loading(t('ns_common:notification.processing_request'), { id: 'update_signature' })
-
-			// setImageURL(optimizedBase64)
+			const base64Image = canvasRef.current?.toDataURL('image/webp', 0.8)
+			const compressedBase64 = await compress(base64Image, {
+				type: 'image/webp',
+				width: 300,
+				height: 200,
+				max: 5, // Max 10KB
+				quality: 1
+			})
+			const originalSizeInKB = (base64Image.length * 3) / 4 / 1024
+			const sizeInKB = (compressedBase64.length * 3) / 4 / 1024
+			console.info(`Signature image compressed from ${originalSizeInKB.toFixed(2)} KB to ${sizeInKB.toFixed(2)} KB`)
 			await setStatusAsync({
 				signature_type: dialogData.current.signature_type,
 				dispatch_order: dialogData.current.dispatch_order,
-				signature: optimizedBase64 ?? '',
+				signature: compressedBase64,
 				...((dialogData.current.signature_type === 'security_1_signature' ||
 					dialogData.current.signature_type === 'security_2_signature') && { approval_status: statusToUpdate })
 			})
@@ -195,19 +105,11 @@ const SignatureEditorDialog: React.FC = () => {
 	}
 
 	const handleClearSignature = () => {
-		$svg.current?.clear()
-		setPoints([])
+		canvasRef.current.clear()
 	}
 
-	const isMissingSignature = !debouncedPoints.length && isSubmitted
-
 	return (
-		<Dialog
-			open={open}
-			onOpenChange={(open) => {
-				setOpen(open)
-				if (!open) setPoints([])
-			}}>
+		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogContent className='max-w-2xl grid-rows-[auto_1fr_auto] md:h-[85vh] xl:max-w-4xl'>
 				<DialogHeader className='mb-6'>
 					<DialogTitle>{dialogData.current.title}</DialogTitle>
@@ -229,9 +131,7 @@ const SignatureEditorDialog: React.FC = () => {
 									setStatusToUpdate(
 										value as TruckloadDeliveryStatus.CONFIRMED | TruckloadDeliveryStatus.REQUEST_CHANGE
 									)
-									if (value === TruckloadDeliveryStatus.REQUEST_CHANGE) {
-										handleClearSignature()
-									}
+									if (value === TruckloadDeliveryStatus.REQUEST_CHANGE) handleClearSignature()
 								}}>
 								<FieldLabel htmlFor='confirm-radio' className='p-4 duration-200 hover:border-primary'>
 									<Field orientation='horizontal'>
@@ -271,40 +171,21 @@ const SignatureEditorDialog: React.FC = () => {
 						<Div
 							id='signature'
 							aria-invalid={isMissingSignature}
-							className='relative max-h-full min-h-[50vh] flex-1 basis-full overflow-clip rounded-md border duration-200 aria-[readonly=true]:!border aria-[invalid=true]:border-destructive hover:border-primary aria-[invalid=true]:hover:border-destructive aria-[readonly=true]:hover:border-border'>
+							className='relative max-h-full min-h-[50vh] flex-1 basis-full overflow-clip rounded-md border bg-white shadow-sm duration-200 aria-[invalid=true]:border-destructive'>
 							{isCompressing && <OptimizingLoader />}
 							<SignatureCanvas
-								penColor='black'
-								ref={$svg}
-								canvasProps={{ className: 'sigCanvas' }}
-								onBegin={(e) => console.log(e)}
-							/>
-							{/* <Signature
-								ref={$svg}
-								fill='hsl(var(--foreground))'
-								className='aria-readonly:cursor-not-allowed'
-								style={signatureStyle}
-								onPointer={handlePoints}
-								options={{
-									size: 6,
-									smoothing: 0.46,
-									thinning: 0.73,
-									streamline: 0.5,
-									easing: (t) => t,
-									simulatePressure: true,
-									last: true,
-									start: {
-										cap: true,
-										taper: 0,
-										easing: (t) => t
-									},
-									end: {
-										cap: true,
-										taper: 0,
-										easing: (t) => t
-									}
+								ref={canvasRef}
+								backgroundColor='transparent'
+								canvasProps={{
+									className: 'w-full h-full bg-transparent'
 								}}
-							/> */}
+								minWidth={2}
+								maxWidth={2}
+								onEnd={() => {
+									const data = canvasRef.current.toData()
+									isEmpty.current = data.length === 0
+								}}
+							/>
 						</Div>
 						{isMissingSignature && (
 							<Typography variant='small' color='destructive' className='font-medium'>
@@ -313,36 +194,14 @@ const SignatureEditorDialog: React.FC = () => {
 						)}
 					</Div>
 				</Div>
-				<DialogFooter className='flex-row items-center justify-between'>
-					<Div className='flex items-center gap-x-2'>
-						<RadioGroup
-							className='flex items-center gap-x-6'
-							value={base64ImageFormat}
-							defaultValue={'webp'}
-							onValueChange={(value) => setBase64ImageFormat(value as 'svg' | 'webp')}>
-							<Div className='flex items-center gap-3'>
-								<RadioGroupItem value='webp' id='webp' />
-								<Label htmlFor='webp' className='inline-flex items-center gap-x-2'>
-									WEBP (Compressed)
-								</Label>
-							</Div>
-							<Div className='flex items-center gap-3'>
-								<RadioGroupItem value='svg' id='svg' />
-								<Label htmlFor='svg' className='inline-flex items-center gap-x-2'>
-									SVG (Optimized)
-								</Label>
-							</Div>
-						</RadioGroup>
-					</Div>
-					<Div className='flex items-center gap-x-2'>
-						<Button variant='secondary' onClick={() => handleClearSignature()}>
-							{t('ns_common:actions.reset')}
-						</Button>
-						<Button disabled={isPending} onClick={() => handleSignSignature()}>
-							{isPending && <Icon name='LoaderCircle' className='animate-spin' />}
-							{isError ? t('ns_common:actions.retry') : t('ns_common:actions.confirm')}
-						</Button>
-					</Div>
+				<DialogFooter>
+					<Button variant='secondary' onClick={() => handleClearSignature()}>
+						{t('ns_common:actions.reset')}
+					</Button>
+					<Button disabled={isPending} onClick={() => handleSignSignature()}>
+						{isPending && <Icon name='LoaderCircle' className='animate-spin' />}
+						{isError ? t('ns_common:actions.retry') : t('ns_common:actions.confirm')}
+					</Button>
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>
@@ -351,32 +210,8 @@ const SignatureEditorDialog: React.FC = () => {
 
 const OptimizingLoader: React.FC = () => {
 	return (
-		<div className='absolute inset-0 z-10 flex flex-col place-content-center place-items-center items-center justify-center gap-x-2 bg-muted/50 backdrop-blur duration-200 animate-in fade-in-0'>
-			<style>{
-				/* CSS */ `
-               .loader {
-                  --c:no-repeat linear-gradient(#fafafa 0 0);
-                  background:
-                     var(--c),var(--c),var(--c),
-                     var(--c),var(--c),var(--c),
-                     var(--c),var(--c),var(--c);
-                  background-size: 8px 8px;
-                  border-radius: 2px;
-                  animation:
-                     l32-1 1s infinite,
-                     l32-2 1s infinite;
-                  }
-                  @keyframes l32-1 {
-                  0%,100% {width:24px;height: 24px}
-                  35%,65% {width:32px;height: 32px}
-                  }
-                  @keyframes l32-2 {
-                  0%,40%  {background-position: 0 0,0 50%, 0 100%,50% 100%,100% 100%,100% 50%,100% 0,50% 0,  50% 50% }
-                  60%,100%{background-position: 0 50%, 0 100%,50% 100%,100% 100%,100% 50%,100% 0,50% 0,0 0,  50% 50% }
-                  }
-            `
-			}</style>
-			<div className='loader' />
+		<div className='absolute inset-0 z-10 grid flex-col place-items-center gap-x-2 bg-muted/50 backdrop-blur duration-200 animate-in fade-in-0'>
+			<Icon name='LoaderCircle' className='animate-spin' />
 		</div>
 	)
 }


### PR DESCRIPTION
This pull request replaces the `@uiw/react-signature` signature input component with `react-signature-canvas` in the truckload delivery feature. The change simplifies the signature capture logic, removes SVG-based signature processing, and updates related dependencies accordingly.

**Signature input component migration:**

- Replaced `@uiw/react-signature` with `react-signature-canvas` in `signature-editor-dialog.tsx`, simplifying the signature capture and processing logic and removing SVG and points-based handling. [[1]](diffhunk://#diff-4ba6453f7677176fad67bc13c28d88385818e2e8fba8cf3d896c14dda293d212L1-L6) [[2]](diffhunk://#diff-4ba6453f7677176fad67bc13c28d88385818e2e8fba8cf3d896c14dda293d212L28-L44) [[3]](diffhunk://#diff-4ba6453f7677176fad67bc13c28d88385818e2e8fba8cf3d896c14dda293d212L63-R56) [[4]](diffhunk://#diff-4ba6453f7677176fad67bc13c28d88385818e2e8fba8cf3d896c14dda293d212L81-R94) [[5]](diffhunk://#diff-4ba6453f7677176fad67bc13c28d88385818e2e8fba8cf3d896c14dda293d212L197-R112) [[6]](diffhunk://#diff-4ba6453f7677176fad67bc13c28d88385818e2e8fba8cf3d896c14dda293d212L231-R134) [[7]](diffhunk://#diff-4ba6453f7677176fad67bc13c28d88385818e2e8fba8cf3d896c14dda293d212L273-R186) [[8]](diffhunk://#diff-4ba6453f7677176fad67bc13c28d88385818e2e8fba8cf3d896c14dda293d212L309-L338)
- Updated the signature compression logic to work directly with the canvas data, removing the option to select between SVG and WEBP formats and always using WEBP. [[1]](diffhunk://#diff-4ba6453f7677176fad67bc13c28d88385818e2e8fba8cf3d896c14dda293d212L81-R94) [[2]](diffhunk://#diff-4ba6453f7677176fad67bc13c28d88385818e2e8fba8cf3d896c14dda293d212L309-L338)

**Dependency updates:**

- Removed `@uiw/react-signature` and its dependencies (`perfect-freehand`) from `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L88) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL191-L193) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6020-L6022) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11075-L11081) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13772-L13773)
- Added `react-signature-canvas` and its dependencies (`signature_pad`, `trim-canvas`, `@types/signature_pad`) to `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R123) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR296-R298) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3501-R3503) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6440-R6453) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6793-R6795) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7172-R7174) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR10998-R10999) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14190-R14201) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14611-R14612) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR15049-R15050)

These changes streamline the signature input experience and reduce the complexity of the codebase by removing SVG manipulation and unnecessary dependencies.